### PR TITLE
avoid  uninitialized constant Rails::Railtie  for non rails < 3 apps

### DIFF
--- a/lib/hirefire.rb
+++ b/lib/hirefire.rb
@@ -103,5 +103,9 @@ end
 # in their application manually, after loading the worker library (either "Delayed Job" or "Resque")
 # and the desired mapper (ActiveRecord, Mongoid or Redis)
 if defined?(Rails)
-  require File.join(HireFire::HIREFIRE_PATH, 'railtie')
+  if Rails.version.to_i >= 3
+    require File.join(HireFire::FREELANCER_PATH, 'railtie')
+  else
+    HireFire::Initializer.initialize!
+  end
 end


### PR DESCRIPTION
Hi meskyanichi , 

im having errors in non rails 3 apps , 
i have done a change in the hirefire.rb file to only require the railtie for rails 3 apps , if the app is rails < 3 it calls the initializer directly.

thanks for your work
