### PR TITLE
Gracefully log and return from Heroku-derived RestClient exceptions.

### DIFF
--- a/lib/hirefire/environment/base.rb
+++ b/lib/hirefire/environment/base.rb
@@ -60,7 +60,7 @@ module HireFire
       # @return [nil]
       def hire
         jobs_count    = jobs
-        workers_count = workers
+        workers_count = workers || return
 
         ##
         # Use "Standard Notation"

--- a/lib/hirefire/environment/heroku.rb
+++ b/lib/hirefire/environment/heroku.rb
@@ -31,6 +31,12 @@ module HireFire
         # Sets the amount of Delayed Job
         # workers that need to be running on Heroku
         client.set_workers(ENV['APP_NAME'], amount)
+
+      rescue RestClient::Exception
+        # Heroku library uses rest-client, currently, and it is quite
+        # possible to receive RestClient exceptions through the client.
+        HireFire::Logger.message("Worker query request failed with #{ $!.class.name } #{ $!.message }")
+        nil
       end
 
       ##

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -228,6 +228,15 @@ describe HireFire::Environment::Base do
         base.expects(:workers).with(5).never
         base.hire
       end
+
+      it 'should NEVER do API requests to Heroku if the workers query returns nil' do
+        base.jobs    = 100
+        base.workers = nil
+
+        base.expects(:log_and_hire).never
+        base.expects(:fire).never
+        base.hire
+      end
     end
 
     describe 'the Lambda (functional) notation' do


### PR DESCRIPTION
This patch rescues from `RestClient::Exception`-based exceptions in the Heroku environment.  When they occur, the `workers` method always logs that an error has occurred and returns `nil`.  I also updated the environment to gracefully return when nil workers are found and added a test case for this scenario.

This should more-or-less hide the fact that an API / connection exception has occurred from the client application, since no errors will bubble up, anymore.  Obviously, the down side, though, is that there is a chance that a worker might not spin up at all if you were at 0 workers and a new job has just come in.  However, since there is really no other interface to the hirefire library from within the application, I feel like it's probably a fair trade-off, since the library is otherwise invisible, anyway.
