### PR TITLE
Add min_workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ And that's it. Next time you deploy to [Heroku](http://heroku.com/) it'll automa
     HireFire.configure do |config|
       config.environment      = nil # default in production is :heroku. default in development is :noop
       config.max_workers      = 5   # default is 1
+      config.min_workers      = 0   # default is 0
       config.job_worker_ratio = [
           { :jobs => 1,   :workers => 1 },
           { :jobs => 15,  :workers => 2 },

--- a/lib/hirefire/configuration.rb
+++ b/lib/hirefire/configuration.rb
@@ -8,6 +8,12 @@ module HireFire
     #
     # @return [Fixnum] default: 1
     attr_accessor :max_workers
+    
+    ##
+    # Contains the min amount of workers that should always be running
+    #
+    # @return [Fixnum] default: 0
+    attr_accessor :min_workers
 
     ##
     # Contains the job/worker ratio which determines
@@ -33,6 +39,7 @@ module HireFire
     # @return [HireFire::Configuration]
     def initialize
       @max_workers      = 1
+      @min_workers      = 0
       @job_worker_ratio = [
           { :jobs => 1,   :workers => 1 },
           { :jobs => 25,  :workers => 2 },

--- a/lib/hirefire/environment/base.rb
+++ b/lib/hirefire/environment/base.rb
@@ -160,13 +160,13 @@ module HireFire
       # or "updated, unless the job didn't fail"
       #
       # If there are workers active, but there are no more pending jobs,
-      # then fire all the workers
+      # then fire all the workers or set to the minimum_workers
       #
       # @return [nil]
       def fire
-        if jobs == 0 and workers > 0
-          Logger.message("All queued jobs have been processed. Firing all workers.")
-          workers(0)
+        if jobs == 0 and workers > min_workers
+          Logger.message("All queued jobs have been processed. " + (min_workers > 0 ? "Setting workers to #{min_workers}." : "Firing all workers."))
+          workers(min_workers)
         end
       end
 
@@ -188,6 +188,15 @@ module HireFire
       # @return [Fixnum] the max amount of workers that are allowed to run concurrently
       def max_workers
         HireFire.configuration.max_workers
+      end
+      
+      ##
+      # Wrapper method for HireFire.configuration
+      # Returns the min amount of workers that should always be running
+      #
+      # @return [Fixnum] the min amount of workers that should always be running
+      def min_workers
+        HireFire.configuration.min_workers
       end
 
       ##

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -9,6 +9,7 @@ describe HireFire::Configuration do
 
     configuration.environment.should      == nil
     configuration.max_workers.should      == 1
+    configuration.min_workers.should      == 0
     configuration.job_worker_ratio.should == [
         { :jobs => 1,   :workers => 1 },
         { :jobs => 25,  :workers => 2 },
@@ -22,6 +23,7 @@ describe HireFire::Configuration do
     HireFire.configure do |config|
       config.environment      = :noop
       config.max_workers      = 10
+      config.min_workers      = 0
       config.job_worker_ratio = [
           { :jobs => 1,   :workers => 1 },
           { :jobs => 15,  :workers => 2 },
@@ -35,6 +37,7 @@ describe HireFire::Configuration do
 
     configuration.environment.should      == :noop
     configuration.max_workers.should      == 10
+    configuration.min_workers.should      == 0
     configuration.job_worker_ratio.should == [
         { :jobs => 1,   :workers => 1 },
         { :jobs => 15,  :workers => 2 },

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -100,6 +100,16 @@ describe HireFire::Environment::Base do
       base.expects(:workers).with(0).once
       base.fire
     end
+    
+    it 'should set the workers to minimum workers when there arent any jobs' do
+      base.jobs    = 0
+      base.workers = 10
+      base.stubs(:min_workers).returns(2)
+      
+      HireFire::Logger.expects(:message).with('All queued jobs have been processed. Setting workers to 2.')
+      base.expects(:workers).with(2).once
+      base.fire
+    end
   end
 
   describe '#hire' do


### PR DESCRIPTION
This patch adds an option to specify min_workers (defaults to 0)

It's not always necessary to have no workers running for cost savings, so sometimes leaving one worker running continuously can be desirable.

Additionally future scheduled jobs are sometimes handy, so the option to keep one worker running can be useful.
