### PR TITLE
Add configuration helper to replace config stubs

### DIFF
--- a/lib/hirefire.rb
+++ b/lib/hirefire.rb
@@ -56,43 +56,49 @@ module HireFire
     end
   end
 
-  ##
-  # This method is used to configure HireFire
-  #
-  # @yield [config] the instance of HireFire::Configuration class
-  # @yieldparam [Fixnum] max_workers default: 1 (set at least 1)
-  # @yieldparam [Array] job_worker_ratio default: see example
-  # @yieldparam [Symbol, nil] environment (:heroku, :local, :noop or nil) - default: nil
-  #
-  # @note Every param has it's own defaults. It's best to leave the environment param at "nil".
-  #   When environment is set to "nil", it'll default to the :noop environment. This basically means
-  #   that you have to run "rake jobs:work" yourself from the console to get the jobs running in development mode.
-  #   In production, it'll automatically use :heroku if deployed to the Heroku platform.
-  #
-  # @example
-  #   HireFire.configure do |config|
-  #     config.environment      = nil
-  #     config.max_workers      = 5
-  #     config.min_workers      = 0
-  #     config.job_worker_ratio = [
-  #       { :jobs => 1,   :workers => 1 },
-  #       { :jobs => 15,  :workers => 2 },
-  #       { :jobs => 35,  :workers => 3 },
-  #       { :jobs => 60,  :workers => 4 },
-  #       { :jobs => 80,  :workers => 5 }
-  #     ]
-  #   end
-  #
-  # @return [nil]
-  def self.configure
-    yield(configuration); nil
-  end
+  class << self
+    
+    attr_writer :configuration
+    
+    ##
+    # This method is used to configure HireFire
+    #
+    # @yield [config] the instance of HireFire::Configuration class
+    # @yieldparam [Fixnum] max_workers default: 1 (set at least 1)
+    # @yieldparam [Array] job_worker_ratio default: see example
+    # @yieldparam [Symbol, nil] environment (:heroku, :local, :noop or nil) - default: nil
+    #
+    # @note Every param has it's own defaults. It's best to leave the environment param at "nil".
+    #   When environment is set to "nil", it'll default to the :noop environment. This basically means
+    #   that you have to run "rake jobs:work" yourself from the console to get the jobs running in development mode.
+    #   In production, it'll automatically use :heroku if deployed to the Heroku platform.
+    #
+    # @example
+    #   HireFire.configure do |config|
+    #     config.environment      = nil
+    #     config.max_workers      = 5
+    #     config.min_workers      = 0
+    #     config.job_worker_ratio = [
+    #       { :jobs => 1,   :workers => 1 },
+    #       { :jobs => 15,  :workers => 2 },
+    #       { :jobs => 35,  :workers => 3 },
+    #       { :jobs => 60,  :workers => 4 },
+    #       { :jobs => 80,  :workers => 5 }
+    #     ]
+    #   end
+    #
+    # @return [nil]
+    def configure
+      yield(configuration); nil
+    end
 
-  ##
-  # Instantiates a new HireFire::Configuration
-  # instance and instance variable caches it
-  def self.configuration
-    @configuration ||= HireFire::Configuration.new
+    ##
+    # Instantiates a new HireFire::Configuration
+    # instance and instance variable caches it
+    def configuration
+      @configuration ||= HireFire::Configuration.new
+    end
+    
   end
 
 end

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -102,27 +102,30 @@ describe HireFire::Environment::Base do
     end
 
     it 'should set the workers to minimum workers when there arent any jobs' do
-      base.jobs    = 0
-      base.workers = 10
-      base.stubs(:min_workers).returns(2)
+      with_min_workers(2) do
+        base.jobs          = 0
+        base.workers       = 10
 
-      HireFire::Logger.expects(:message).with('All queued jobs have been processed. Setting workers to 2.')
-      base.expects(:workers).with(2).once
-      base.fire
+        HireFire::Logger.expects(:message).with('All queued jobs have been processed. Setting workers to 2.')
+        base.expects(:workers).with(2).once
+        base.fire
+      end
     end
   end
 
   describe '#hire' do
     describe 'the standard notation' do
       before do
-        base.stubs(:max_workers).returns(5)
-        base.stubs(:ratio).returns([
-          { :jobs => 1,  :workers => 1 },
-          { :jobs => 15, :workers => 2 },
-          { :jobs => 30, :workers => 3 },
-          { :jobs => 60, :workers => 4 },
-          { :jobs => 90, :workers => 5 }
-        ])
+        configure do |config|
+          config.max_workers = 5
+          config.job_worker_ratio = [
+            { :jobs => 1,  :workers => 1 },
+            { :jobs => 15, :workers => 2 },
+            { :jobs => 30, :workers => 3 },
+            { :jobs => 60, :workers => 4 },
+            { :jobs => 90, :workers => 5 }
+          ]
+        end
       end
 
       it 'should request 1 worker' do
@@ -178,56 +181,62 @@ describe HireFire::Environment::Base do
       end
 
       it 'should NEVER hire more workers than the #max_workers' do
-        base.jobs    = 100
-        base.workers = 0
+        with_max_workers(3) do
+          base.jobs    = 100
+          base.workers = 0
 
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
-        base.expects(:workers).with(3).once
-        base.hire
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
+          base.expects(:workers).with(3).once
+          base.hire
+        end
       end
 
       it 'should not hire 5 workers even if defined in the job/ratio, when the limit is 3, it should hire 3 max' do
-        base.jobs    = 100
-        base.workers = 0
-
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-        base.stubs(:ratio).returns([
-          { :jobs => 5, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
-        base.expects(:workers).with(3).once
-        base.hire
+        with_configuration do |config|
+          config.max_workers = 3
+          config.job_worker_ratio = [
+            { :jobs => 5, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 0
+          
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
+          base.expects(:workers).with(3).once
+          base.hire
+        end
       end
 
       it 'should not hire (or invoke) any more workers since the max amount allowed is already running' do
-        base.jobs    = 100
-        base.workers = 3
+        with_configuration do |config|
+          config.max_workers = 3
+          config.job_worker_ratio = [
+            { :jobs => 5, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 3
 
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-        base.stubs(:ratio).returns([
-          { :jobs => 5, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').never
-        base.expects(:workers).with(3).never
-        base.hire
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').never
+          base.expects(:workers).with(3).never
+          base.hire
+        end
       end
 
       it 'the max_workers option can only "limit" the amount of max_workers when used in the "Standard Notation"' do
-        base.jobs    = 100
-        base.workers = 0
+        with_configuration do |config|
+          config.max_workers = 10
+          config.job_worker_ratio = [
+            { :jobs => 5, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 0
 
-        base.stubs(:max_workers).returns(10) # set the max_workers = 10
-        base.stubs(:ratio).returns([
-          { :jobs => 5, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 5 in total.').once
-        base.expects(:workers).with(5).once
-        base.hire
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 5 in total.').once
+          base.expects(:workers).with(5).once
+          base.hire
+        end
       end
 
       it 'should NEVER do API requests to Heroku if the max_workers are already running' do
@@ -251,13 +260,15 @@ describe HireFire::Environment::Base do
 
     describe 'the Lambda (functional) notation' do
       before do
-        base.stubs(:max_workers).returns(5)
-        base.stubs(:ratio).returns([
-          { :when => lambda {|jobs| jobs < 15 }, :workers => 1 },
-          { :when => lambda {|jobs| jobs < 30 }, :workers => 2 },
-          { :when => lambda {|jobs| jobs < 60 }, :workers => 3 },
-          { :when => lambda {|jobs| jobs < 90 }, :workers => 4 }
-        ])
+        configure do |config|
+          config.max_workers = 5
+          config.job_worker_ratio = [
+            { :when => lambda {|jobs| jobs < 15 }, :workers => 1 },
+            { :when => lambda {|jobs| jobs < 30 }, :workers => 2 },
+            { :when => lambda {|jobs| jobs < 60 }, :workers => 3 },
+            { :when => lambda {|jobs| jobs < 90 }, :workers => 4 }
+          ]
+        end
       end
 
       it 'should request 1 worker' do
@@ -313,56 +324,63 @@ describe HireFire::Environment::Base do
       end
 
       it 'should NEVER hire more workers than the #max_workers' do
-        base.jobs    = 100
-        base.workers = 0
-
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
-        base.expects(:workers).with(3).once
-        base.hire
+        with_configuration do |config|
+          config.max_workers = 3
+          base.jobs    = 100
+          base.workers = 0
+          
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
+          base.expects(:workers).with(3).once
+          base.hire
+        end
       end
 
       it 'should not hire 5 workers even if defined in the job/ratio, when the limit is 3, it should hire 3 max' do
-        base.jobs    = 100
-        base.workers = 0
-
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-        base.stubs(:ratio).returns([
-          { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
-        base.expects(:workers).with(3).once
-        base.hire
+        with_configuration do |config|
+          config.max_workers = 3
+          config.job_worker_ratio = [
+            { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 0
+          
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').once
+          base.expects(:workers).with(3).once
+          base.hire   
+        end
       end
 
       it 'should not hire (or invoke) any more workers since the max amount allowed is already running' do
-        base.jobs    = 100
-        base.workers = 3
-
-        base.stubs(:max_workers).returns(3) # set the max_workers = 3
-        base.stubs(:ratio).returns([
-          { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').never
-        base.expects(:workers).with(3).never
-        base.hire
+        with_configuration do |config|
+          config.max_workers = 3
+          config.job_worker_ratio = [
+            { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 3
+          
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 3 in total.').never
+          base.expects(:workers).with(3).never
+          base.hire
+        end
       end
 
       it 'the max_workers option can only "limit" the amount of max_workers when used in the "Standard Notation"' do
-        base.jobs    = 100
-        base.workers = 0
+        with_configuration do |config|
+          config.max_workers = 10
+          config.job_worker_ratio = [
+            { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
+          ]
+          
+          base.jobs    = 100
+          base.workers = 0
 
-        base.stubs(:max_workers).returns(10) # set the max_workers = 10
-        base.stubs(:ratio).returns([
-          { :when => lambda { |jobs| jobs < 5 }, :workers => 5 }
-        ])
-
-        HireFire::Logger.expects(:message).with('Hiring more workers so we have 10 in total.').once
-        base.expects(:workers).with(10).once
-        base.hire
+          HireFire::Logger.expects(:message).with('Hiring more workers so we have 10 in total.').once
+          base.expects(:workers).with(10).once
+          base.hire
+        end
       end
 
       it 'should NEVER do API requests to Heroku if the max_workers are already running' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,37 @@ LIB_PATH = File.expand_path('../../lib', __FILE__)
 # Load the HireFire Ruby library
 require File.join(LIB_PATH, 'hirefire')
 
+module ConfigurationHelper
+  
+  def configure(&block)
+    HireFire.configure(&block)
+  end
+  
+  def with_configuration(&block)
+    old_configuration = HireFire.configuration
+    HireFire.configuration = HireFire::Configuration.new
+    yield(HireFire.configuration)
+    HireFire.configuration = old_configuration
+  end
+  
+  def with_max_workers(workers, &block)
+    with_configuration do |config|
+      config.max_workers = workers
+      yield
+    end
+  end
+  
+  def with_min_workers(workers, &block)
+    with_configuration do |config|
+      config.min_workers = workers
+      yield
+    end
+  end
+end
+
 ##
 # Use Mocha to mock with RSpec
 RSpec.configure do |config|
   config.mock_with :mocha
+  config.include ConfigurationHelper
 end


### PR DESCRIPTION
Removes the need for the configuration stubs in spec/environment_spec.rb (suggestion & help from @nbibler)
