### PR TITLE
relax the dependency on heroku

### DIFF
--- a/hirefire.gemspec
+++ b/hirefire.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   ##
   # Production gem dependencies
-  gem.add_dependency 'heroku', ['~> 2.0.0']
+  gem.add_dependency 'heroku', ['>= 1.4']
   gem.add_dependency 'rush',   ['~> 0.6.7']
 
 end


### PR DESCRIPTION
Heroku bumped the version of their gem to 2.1.3.
And their internal gems are depending on that version. 
Ie. pgbackups requires heroku > 2.1.2

Currently hirefire has a fairly strict dependency on heroku (~> 2.0.0).
Hirefire uses a total of 3 methods from the heroku gem api:
- Client.initialize
- Client.info
- Client.set_workers

These methods haven't changed since heroku version 1.4.  I propose to loosen the dependency to >= 1.4.
In the unlikely event that the api will change, the requirement can be clamped to something alng the lines of  [">= 1.4", "< 3"]
