### PR TITLE
updates heroku gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,14 @@ GEM
       rspec (~> 2.0)
       rspec-instafail (~> 0.1.4)
       ruby-progressbar (~> 0.0.9)
-    heroku (1.20.1)
-      launchy (~> 0.3.2)
-      rest-client (< 1.7.0, >= 1.4.0)
+    heroku (2.1.4)
+      launchy (>= 0.3.2)
+      rest-client (~> 1.6.1)
+      term-ansicolor (~> 1.0.5)
     infinity_test (1.0.2)
       notifiers (>= 1.1.0)
       watchr (>= 0.7)
-    launchy (0.3.7)
+    launchy (0.4.0)
       configuration (>= 0.0.5)
       rake (>= 0.8.1)
     mime-types (1.16)
@@ -37,6 +38,7 @@ GEM
       session
     session (3.1.0)
       fattr
+    term-ansicolor (1.0.5)
     timecop (0.3.5)
     watchr (0.7)
 


### PR DESCRIPTION
Heroku requires gem to be in version 2.1.x to use the API. So, i've updated the Gemfile and ran the tests. Everything seems to be working fine.
