### PR TITLE
don't exit the job polling loop unless the environment says so

### DIFF
--- a/lib/hirefire/environment/base.rb
+++ b/lib/hirefire/environment/base.rb
@@ -163,12 +163,16 @@ module HireFire
       # If there are workers active, but there are no more pending jobs,
       # then fire all the workers or set to the minimum_workers
       #
-      # @return [nil]
+      # @return [Boolean] if the workers have been fired
       def fire
         if jobs == 0 and workers > min_workers
           Logger.message("All queued jobs have been processed. " + (min_workers > 0 ? "Setting workers to #{min_workers}." : "Firing all workers."))
           workers(min_workers)
+
+          return true
         end
+
+        return false
       end
 
       private

--- a/lib/hirefire/workers/delayed_job/worker.rb
+++ b/lib/hirefire/workers/delayed_job/worker.rb
@@ -59,8 +59,7 @@ module Delayed
         # If this is the case it'll command the current environment to fire all the hired workers
         # and then immediately break out of this infinite loop.
         if queued.jobs == 0
-          Delayed::Job.environment.fire
-          break
+          break if Delayed::Job.environment.fire
         end
 
         break if $exit

--- a/lib/hirefire/workers/resque/worker.rb
+++ b/lib/hirefire/workers/resque/worker.rb
@@ -41,11 +41,10 @@ module ::Resque
           # If this is the case it'll command the current environment to fire all the hired workers
           # and then immediately break out of this infinite loop.
           if (::Resque::Job.jobs + ::Resque::Job.working) == 0
-            ::Resque::Job.environment.fire
-            break
-          else
-            sleep(interval)
+            break if ::Resque::Job.environment.fire
           end
+
+          sleep(interval)
 
         end
       end


### PR DESCRIPTION
This should fix #21: Killing "rake jobs:work" process in local environment (development environment)
