### PR TITLE
Ignores run_at attribute when counting pending jobs

### DIFF
--- a/lib/hirefire/backend/delayed_job/active_record.rb
+++ b/lib/hirefire/backend/delayed_job/active_record.rb
@@ -13,7 +13,6 @@ module HireFire
         def jobs
           ::Delayed::Job.
           where(:failed_at => nil).count
-          #where('run_at <= ?', Time.now).count
         end
 
         ##

--- a/lib/hirefire/backend/delayed_job/active_record_2.rb
+++ b/lib/hirefire/backend/delayed_job/active_record_2.rb
@@ -12,7 +12,7 @@ module HireFire
         # @return [Fixnum] the amount of pending jobs
         def jobs
           ::Delayed::Job.all(
-            :conditions => ['failed_at IS NULL and run_at <= ?', Time.now.utc]
+            :conditions => 'failed_at IS NULL'
           ).count
         end
 


### PR DESCRIPTION
In our delayed_job setup, we set Delayed::Worker.max_attempts to 3.

When a job fails, it will be scheduled to be retried some time in the future (created_at + 2^attempts seconds). The problem is that Hirefire counts the pending jobs with run_at <= Time.now, excluding the jobs that need to be retried. This makes the workers go back to zero, and the failed job keeps pending. It will only be run when/if some other process sets up a new (unrelated) job.

This change ignores the run_at attribute when counting pending jobs.
