### PR TITLE
Develop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # encoding: utf-8
 
 source 'http://rubygems.org'
+source "http://tgpgems:c3po42@gems.thegiantpixel.com/"
+
+gem 'tgp_gem', :path => "../tgp_gem"
 
 ##
 # Define gems to be used in the 'test' environment

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'http://rubygems.org'
 ##
 # Define gems to be used in the 'test' environment
 group :test do
-  gem 'heroku'
+  gem 'heroku-api'
   gem 'rush'
   gem 'rspec'
   gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,37 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    configuration (1.2.0)
-    diff-lcs (1.1.2)
-    fattr (2.2.0)
-    fuubar (0.0.3)
+    diff-lcs (1.1.3)
+    excon (0.16.7)
+    fattr (2.2.1)
+    fuubar (1.1.0)
       rspec (~> 2.0)
-      rspec-instafail (~> 0.1.4)
-      ruby-progressbar (~> 0.0.9)
-    heroku (1.20.1)
-      launchy (~> 0.3.2)
-      rest-client (< 1.7.0, >= 1.4.0)
-    infinity_test (1.0.2)
+      rspec-instafail (~> 0.2.0)
+      ruby-progressbar (~> 1.0.0)
+    heroku-api (0.3.5)
+      excon (~> 0.16.1)
+    infinity_test (1.0.3)
       notifiers (>= 1.1.0)
       watchr (>= 0.7)
-    launchy (0.3.7)
-      configuration (>= 0.0.5)
-      rake (>= 0.8.1)
-    mime-types (1.16)
-    mocha (0.9.12)
+    metaclass (0.0.1)
+    mocha (0.12.7)
+      metaclass (~> 0.0.1)
     notifiers (1.1.0)
-    rake (0.8.7)
-    rest-client (1.6.1)
-      mime-types (>= 1.16)
-    rspec (2.5.0)
-      rspec-core (~> 2.5.0)
-      rspec-expectations (~> 2.5.0)
-      rspec-mocks (~> 2.5.0)
-    rspec-core (2.5.1)
-    rspec-expectations (2.5.0)
-      diff-lcs (~> 1.1.2)
-    rspec-instafail (0.1.6)
-    rspec-mocks (2.5.0)
-    ruby-progressbar (0.0.9)
-    rush (0.6.7)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.3)
+      diff-lcs (~> 1.1.3)
+    rspec-instafail (0.2.4)
+    rspec-mocks (2.11.3)
+    ruby-progressbar (1.0.2)
+    rush (0.6.8)
       session
     session (3.1.0)
       fattr
-    timecop (0.3.5)
+    timecop (0.5.2)
     watchr (0.7)
 
 PLATFORMS
@@ -45,7 +39,7 @@ PLATFORMS
 
 DEPENDENCIES
   fuubar
-  heroku
+  heroku-api
   infinity_test
   mocha
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,102 @@
+PATH
+  remote: ../tgp_gem
+  specs:
+    tgp_gem (0.0.4)
+      geminabox
+      rails (~> 3.2.8)
+
 GEM
   remote: http://rubygems.org/
+  remote: http://tgpgems:c3po42@gems.thegiantpixel.com/
   specs:
+    actionmailer (3.2.13)
+      actionpack (= 3.2.13)
+      mail (~> 2.5.3)
+    actionpack (3.2.13)
+      activemodel (= 3.2.13)
+      activesupport (= 3.2.13)
+      builder (~> 3.0.0)
+      erubis (~> 2.7.0)
+      journey (~> 1.0.4)
+      rack (~> 1.4.5)
+      rack-cache (~> 1.2)
+      rack-test (~> 0.6.1)
+      sprockets (~> 2.2.1)
+    activemodel (3.2.13)
+      activesupport (= 3.2.13)
+      builder (~> 3.0.0)
+    activerecord (3.2.13)
+      activemodel (= 3.2.13)
+      activesupport (= 3.2.13)
+      arel (~> 3.0.2)
+      tzinfo (~> 0.3.29)
+    activeresource (3.2.13)
+      activemodel (= 3.2.13)
+      activesupport (= 3.2.13)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
+      multi_json (~> 1.0)
+    arel (3.0.2)
+    builder (3.0.4)
     diff-lcs (1.1.3)
+    erubis (2.7.0)
     excon (0.16.7)
     fattr (2.2.1)
     fuubar (1.1.0)
       rspec (~> 2.0)
       rspec-instafail (~> 0.2.0)
       ruby-progressbar (~> 1.0.0)
+    geminabox (0.10.1)
+      builder
+      httpclient (>= 2.2.7)
+      sinatra
     heroku-api (0.3.5)
       excon (~> 0.16.1)
+    hike (1.2.2)
+    httpclient (2.3.3)
+    i18n (0.6.1)
     infinity_test (1.0.3)
       notifiers (>= 1.1.0)
       watchr (>= 0.7)
+    journey (1.0.4)
+    json (1.8.0)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
     metaclass (0.0.1)
+    mime-types (1.23)
     mocha (0.12.7)
       metaclass (~> 0.0.1)
+    multi_json (1.7.3)
     notifiers (1.1.0)
+    polyglot (0.3.3)
+    rack (1.4.5)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-protection (1.5.0)
+      rack
+    rack-ssl (1.3.3)
+      rack
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rails (3.2.13)
+      actionmailer (= 3.2.13)
+      actionpack (= 3.2.13)
+      activerecord (= 3.2.13)
+      activeresource (= 3.2.13)
+      activesupport (= 3.2.13)
+      bundler (~> 1.0)
+      railties (= 3.2.13)
+    railties (3.2.13)
+      actionpack (= 3.2.13)
+      activesupport (= 3.2.13)
+      rack-ssl (~> 1.3.2)
+      rake (>= 0.8.7)
+      rdoc (~> 3.4)
+      thor (>= 0.14.6, < 2.0)
+    rake (10.0.4)
+    rdoc (3.12.2)
+      json (~> 1.4)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -31,7 +111,22 @@ GEM
       session
     session (3.1.0)
       fattr
+    sinatra (1.3.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
+      tilt (~> 1.3, >= 1.3.3)
+    sprockets (2.2.2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    thor (0.18.1)
+    tilt (1.4.1)
     timecop (0.5.2)
+    treetop (1.4.12)
+      polyglot
+      polyglot (>= 0.3.1)
+    tzinfo (0.3.37)
     watchr (0.7)
 
 PLATFORMS
@@ -44,4 +139,5 @@ DEPENDENCIES
   mocha
   rspec
   rush
+  tgp_gem!
   timecop

--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ Author
 Drop me a message for any questions, suggestions, requests, bugs or submit them to the [issue log](https://github.com/meskyanichi/hirefire/issues).
 
 
-HireFireApp.com - The Heroku Worker Manager - BETA
---------------------------------------------------
+[HireFireApp.com](http://hirefireapp.com/) - The Heroku Process Manager
+--------------------------------------------
 
-*This is not part of the "HireFire open source" project, but it could potentially help support my open source projects!*
+**This is not part of the open source HireFire**
 
-I would like to announce the release of a **new service** I've been working on, called **HireFireApp**. The goal is essentially the same as the open source HireFire project, except that it's considered more **stable/reliable** and **a lot more performant**.
+[HireFire](http://hirefireapp.com/)(Service) is a hosted service which is based on HireFire(Open Source). The reason this project came about is because of Heroku's platform constraints which made the Open Source project quite unstable/unreliable and reduced performance dramatically on HTTP requests (slow response times when new jobs are being queued). It is also hard to allow both worker as well as dyno scaling, and manage that from within the same process.
 
-The service is currently in beta, so feel free to create a free account and try it out!
+For this reason, I created a hosted web service, based on the open source project. Not only does it support **worker dyno scaling** but it also supports **web dyno scaling**. And next to Heroku's **Badious Bamboo** stack, it also supports Heroku's new stack, **Celadon Cedar**.
 
-Check out the [official website](http://hirefireapp.com) for more information: [http://hirefireapp.com](http://hirefireapp.com)
+If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the hosted service variant of the open source project.
+
+**[http://hirefireapp.com](http://hirefireapp.com)** - We're currently in public beta, so try it for free!
+
 
 
 Setting it up

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Author
 Drop me a message for any questions, suggestions, requests, bugs or submit them to the [issue log](https://github.com/meskyanichi/hirefire/issues).
 
 
+Please Donate!
+--------------
+
+Please consider [DONATING](http://pledgie.com/campaigns/16066) to the HireFire project for the time and effort that was put in to developing the gem! Thanks!
+
+[![Donate to HireFire](http://pledgie.com/campaigns/16066.png)](http://pledgie.com/campaigns/16066)
+
+
 [HireFireApp.com](http://hirefireapp.com/) - The Heroku Process Manager
 --------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ HireFire - The Heroku Worker Manager
 
 **High traffic example** say we have a high traffic application that needs to process a lot of jobs. There may be "traffic spikes" from time to time. In this case you can take advantage of the **job\_worker\_ratio**. Since this is application-specific, HireFire allows you to define how many workers there should be running, depending on the amount of queued jobs there are (see example configuration below). HireFire will then spin up more workers as traffic increases so it can work through the queue faster, then when the jobs are all finished, it'll shut down all the workers again until the next job gets queued (in which case it'll start with only a single worker again).
 
-**Enough with the examples!** Read on to see how to set it, and configure it to your scaling and money saving needs.
-
 Author
 ------
 
@@ -26,9 +24,9 @@ Drop me a message for any questions, suggestions, requests, bugs or submit them 
 
 For this reason, I created a hosted web service, based on the open source project. Not only does it support **worker dyno scaling** but it also supports **web dyno scaling**. And next to Heroku's **Badious Bamboo** stack, it also supports Heroku's new stack, **Celadon Cedar**.
 
-If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the hosted service variant of the open source project.
+If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the HireFire hosted service.
 
-**[http://hirefireapp.com](http://hirefireapp.com)** - We're currently in public beta, so try it for free!
+**[http://hirefireapp.com](http://hirefireapp.com)**
 
 
 

--- a/hirefire.gemspec
+++ b/hirefire.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   ##
   # Production gem dependencies
-  gem.add_dependency 'heroku', ['>= 1.4']
+  gem.add_dependency 'heroku-api', ['-> 0.3.5']
   gem.add_dependency 'rush',   ['~> 0.6.7']
 
 end

--- a/hirefire.gemspec
+++ b/hirefire.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   ##
   # Production gem dependencies
-  gem.add_dependency 'heroku-api', ['-> 0.3.5']
+  gem.add_dependency 'heroku-api', ['~> 0.3.5']
   gem.add_dependency 'rush',   ['~> 0.6.7']
 
 end

--- a/lib/hirefire/backend.rb
+++ b/lib/hirefire/backend.rb
@@ -27,6 +27,10 @@ module HireFire
           end
         end
 
+        if defined?(::Delayed::Backend::DataMapper::Job)
+          base.send(:include, HireFire::Backend::DelayedJob::DataMapper)
+        end
+
         if defined?(::Delayed::Backend::Mongoid::Job)
           base.send(:include, HireFire::Backend::DelayedJob::Mongoid)
         end

--- a/lib/hirefire/backend/delayed_job.rb
+++ b/lib/hirefire/backend/delayed_job.rb
@@ -6,6 +6,7 @@ module HireFire
       autoload :ActiveRecord,  'hirefire/backend/delayed_job/active_record'
       autoload :ActiveRecord2, 'hirefire/backend/delayed_job/active_record_2'
       autoload :Mongoid,       'hirefire/backend/delayed_job/mongoid'
+      autoload :DataMapper,    'hirefire/backend/delayed_job/data_mapper'
     end
   end
 end

--- a/lib/hirefire/backend/delayed_job/data_mapper.rb
+++ b/lib/hirefire/backend/delayed_job/data_mapper.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+module HireFire
+  module Backend
+    module DelayedJob
+      module DataMapper
+
+        ##
+        # Counts the amount of queued jobs in the database,
+        # failed jobs are excluded from the sum
+        #
+        # @return [Fixnum] the amount of pending jobs
+        def jobs
+          ::Delayed::Job.count(:failed_at => nil, :run_at.lte => Time.now.utc)
+        end
+
+        ##
+        # Counts the amount of jobs that are locked by a worker
+        # There is no other performant way to determine the amount
+        # of workers there currently are
+        #
+        # @return [Fixnum] the amount of (assumably working) workers
+        def working
+          ::Delayed::Job.count(:locked_by.not => nil)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/hirefire/configuration.rb
+++ b/lib/hirefire/configuration.rb
@@ -31,6 +31,8 @@ module HireFire
     # @return [Symbol, nil] default: nil
     attr_accessor :environment
 
+    attr_accessor :app_name
+
     ##
     # Instantiates a new HireFire::Configuration object
     # with the default configuration. These default configurations
@@ -38,6 +40,7 @@ module HireFire
     #
     # @return [HireFire::Configuration]
     def initialize
+      @app_name = ENV["APP_NAME"]
       @max_workers      = 1
       @min_workers      = 0
       @job_worker_ratio = [

--- a/lib/hirefire/environment.rb
+++ b/lib/hirefire/environment.rb
@@ -82,7 +82,7 @@ module HireFire
           if environment = HireFire.configuration.environment
             environment.to_s.camelize
           else
-            ENV.include?('HEROKU_UPID') ? 'Heroku' : 'Noop'
+            ::Rails.env.production? ? 'Heroku' : 'Noop'
           end
         ).new
       end

--- a/lib/hirefire/environment.rb
+++ b/lib/hirefire/environment.rb
@@ -42,6 +42,20 @@ module HireFire
           after_update  'self.class.environment.fire',
             :unless => Proc.new { |job| job.failed_at.nil? }
         end
+      elsif base.name == "Delayed::Backend::DataMapper::Job"
+        base.send :extend, HireFire::Environment::DelayedJob::ClassMethods
+
+        base.class_eval do
+          after :create do
+            self.class.hirefire_hire
+          end
+          after :destroy do
+            self.class.environment.fire
+          end
+          after :update do
+            self.class.environment.fire unless self.failed_at.nil?
+          end
+        end
       end
 
       Logger.message("#{ base.name } detected!")

--- a/lib/hirefire/environment/heroku.rb
+++ b/lib/hirefire/environment/heroku.rb
@@ -21,7 +21,7 @@ module HireFire
         # client.set_workers(app_name], amount)
         return client.post_ps_scale(app_name, "worker", amount)
 
-      rescue RestClient::Exception
+      rescue Exception
         HireFire::Logger.message("Worker query request failed with #{ $!.class.name } #{ $!.message }")
         nil
       end

--- a/lib/hirefire/environment/heroku.rb
+++ b/lib/hirefire/environment/heroku.rb
@@ -11,7 +11,7 @@ module HireFire
       def workers(amount = nil)
 
         app_name = HireFire.configuration.app_name
-        puts "HIREFIRE FOR APP #{app_name}"
+        #puts "HIREFIRE FOR APP #{app_name}"
 
         if amount.nil?
           # return client.info(app_name)[:workers].to_i

--- a/lib/hirefire/environment/heroku.rb
+++ b/lib/hirefire/environment/heroku.rb
@@ -27,7 +27,7 @@ module HireFire
       end
 
       def client
-        @client ||= Heroku::API.new # will pick up api_key from configs
+        @client ||= ::Heroku::API.new # will pick up api_key from configs
       end
 
     end

--- a/lib/hirefire/environment/heroku.rb
+++ b/lib/hirefire/environment/heroku.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'heroku'
+require 'heroku-api'
 
 module HireFire
   module Environment
@@ -8,43 +8,26 @@ module HireFire
 
       private
 
-      ##
-      # Either retrieves the amount of currently running workers,
-      # or set the amount of workers to a specific amount by providing a value
-      #
-      # @overload workers(amount = nil)
-      #   @param [Fixnum] amount will tell heroku to run N workers
-      #   @return [nil]
-      # @overload workers(amount = nil)
-      #   @param [nil] amount
-      #   @return [Fixnum] will request the amount of currently running workers from Heroku
       def workers(amount = nil)
 
-        #
-        # Returns the amount of Delayed Job
-        # workers that are currently running on Heroku
+        app_name = HireFire.configuration.app_name
+        puts "HIREFIRE FOR APP #{app_name}"
+
         if amount.nil?
-          return client.info(ENV['APP_NAME'])[:workers].to_i
+          # return client.info(app_name)[:workers].to_i
+          return client.get_ps(app_name).body.select {|p| p['process'] =~ /worker.[0-9]+/}.length
         end
 
-        ##
-        # Sets the amount of Delayed Job
-        # workers that need to be running on Heroku
-        client.set_workers(ENV['APP_NAME'], amount)
+        # client.set_workers(app_name], amount)
+        return client.post_ps_scale(app_name, "worker", amount)
 
       rescue RestClient::Exception
-        # Heroku library uses rest-client, currently, and it is quite
-        # possible to receive RestClient exceptions through the client.
         HireFire::Logger.message("Worker query request failed with #{ $!.class.name } #{ $!.message }")
         nil
       end
 
-      ##
-      # @return [Heroku::Client] instance of the heroku client
       def client
-        @client ||= ::Heroku::Client.new(
-          ENV['HIREFIRE_EMAIL'], ENV['HIREFIRE_PASSWORD']
-        )
+        @client ||= Heroku::API.new # will pick up api_key from configs
       end
 
     end

--- a/lib/hirefire/initializer.rb
+++ b/lib/hirefire/initializer.rb
@@ -44,6 +44,15 @@ module HireFire
         end
 
         ##
+        # If DelayedJob is using DataMapper, then include
+        # HireFire::Environment in to the DataMapper Delayed Job Backend
+        if defined?(::Delayed::Backend::DataMapper::Job)
+          ::Delayed::Backend::DataMapper::Job.
+          send(:include, HireFire::Environment).
+          send(:include, HireFire::Backend)
+        end
+
+        ##
         # Load Delayed Job extensions, this will patch Delayed::Worker
         # to implement the necessary hooks to invoke HireFire from
         require 'hirefire/workers/delayed_job'

--- a/lib/hirefire/version.rb
+++ b/lib/hirefire/version.rb
@@ -6,7 +6,7 @@ module HireFire
     ##
     # @return [String] the current version of the HireFire gem
     def self.current
-      '0.1.5'
+      '0.1.6'
     end
 
   end

--- a/lib/hirefire/version.rb
+++ b/lib/hirefire/version.rb
@@ -6,7 +6,7 @@ module HireFire
     ##
     # @return [String] the current version of the HireFire gem
     def self.current
-      '0.1.4'
+      '0.1.5'
     end
 
   end

--- a/lib/hirefire/workers/resque/worker.rb
+++ b/lib/hirefire/workers/resque/worker.rb
@@ -20,7 +20,7 @@ module ::Resque
           run_hook :before_fork, job
           working_on job
 
-          if @child = fork
+          if @child = fork(job)
             rand # Reseeding
             procline "Forked #{@child} at #{Time.now.to_i}"
             Process.wait


### PR DESCRIPTION
Heroku has deprecated the heroku gem, and now has heroku-api. I've updated it to use that api. 
Resque's fork was missing the job parameter
Added configuration.app_name so the application can set it instead of jumping through hoops to try to get it.
Changed version # so heroku would pick it up.
