### PR TITLE
pass job into the call to fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ Author
 Drop me a message for any questions, suggestions, requests, bugs or submit them to the [issue log](https://github.com/meskyanichi/hirefire/issues).
 
 
-HireFireApp.com - The Heroku Worker Manager - BETA
---------------------------------------------------
+[HireFireApp.com](http://hirefireapp.com/) - The Heroku Process Manager
+--------------------------------------------
 
-*This is not part of the "HireFire open source" project, but it could potentially help support my open source projects!*
+**This is not part of the open source HireFire**
 
-I would like to announce the release of a **new service** I've been working on, called **HireFireApp**. The goal is essentially the same as the open source HireFire project, except that it's considered more **stable/reliable** and **a lot more performant**.
+[HireFire](http://hirefireapp.com/)(Service) is a hosted service which is based on HireFire(Open Source). The reason this project came about is because of Heroku's platform constraints which made the Open Source project quite unstable/unreliable and reduced performance dramatically on HTTP requests (slow response times when new jobs are being queued). It is also hard to allow both worker as well as dyno scaling, and manage that from within the same process.
 
-The service is currently in beta, so feel free to create a free account and try it out!
+For this reason, I created a hosted web service, based on the open source project. Not only does it support **worker dyno scaling** but it also supports **web dyno scaling**. And next to Heroku's **Badious Bamboo** stack, it also supports Heroku's new stack, **Celadon Cedar**.
 
-Check out the [official website](http://hirefireapp.com) for more information: [http://hirefireapp.com](http://hirefireapp.com)
+If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the hosted service variant of the open source project.
+
+**[http://hirefireapp.com](http://hirefireapp.com)** - We're currently in public beta, so try it for free!
+
 
 
 Setting it up

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Author
 Drop me a message for any questions, suggestions, requests, bugs or submit them to the [issue log](https://github.com/meskyanichi/hirefire/issues).
 
 
+Please Donate!
+--------------
+
+Please consider [DONATING](http://pledgie.com/campaigns/16066) to the HireFire project for the time and effort that was put in to developing the gem! Thanks!
+
+[![Donate to HireFire](http://pledgie.com/campaigns/16066.png)](http://pledgie.com/campaigns/16066)
+
+
 [HireFireApp.com](http://hirefireapp.com/) - The Heroku Process Manager
 --------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ HireFire - The Heroku Worker Manager
 
 **High traffic example** say we have a high traffic application that needs to process a lot of jobs. There may be "traffic spikes" from time to time. In this case you can take advantage of the **job\_worker\_ratio**. Since this is application-specific, HireFire allows you to define how many workers there should be running, depending on the amount of queued jobs there are (see example configuration below). HireFire will then spin up more workers as traffic increases so it can work through the queue faster, then when the jobs are all finished, it'll shut down all the workers again until the next job gets queued (in which case it'll start with only a single worker again).
 
-**Enough with the examples!** Read on to see how to set it, and configure it to your scaling and money saving needs.
-
 Author
 ------
 
@@ -26,9 +24,9 @@ Drop me a message for any questions, suggestions, requests, bugs or submit them 
 
 For this reason, I created a hosted web service, based on the open source project. Not only does it support **worker dyno scaling** but it also supports **web dyno scaling**. And next to Heroku's **Badious Bamboo** stack, it also supports Heroku's new stack, **Celadon Cedar**.
 
-If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the hosted service variant of the open source project.
+If you're looking to scale either your web or worker dynos, on either Badious Bamboo or Celadon Cedar, be sure to check out the HireFire hosted service.
 
-**[http://hirefireapp.com](http://hirefireapp.com)** - We're currently in public beta, so try it for free!
+**[http://hirefireapp.com](http://hirefireapp.com)**
 
 
 

--- a/lib/hirefire/backend.rb
+++ b/lib/hirefire/backend.rb
@@ -27,6 +27,10 @@ module HireFire
           end
         end
 
+        if defined?(::Delayed::Backend::DataMapper::Job)
+          base.send(:include, HireFire::Backend::DelayedJob::DataMapper)
+        end
+
         if defined?(::Delayed::Backend::Mongoid::Job)
           base.send(:include, HireFire::Backend::DelayedJob::Mongoid)
         end

--- a/lib/hirefire/backend/delayed_job.rb
+++ b/lib/hirefire/backend/delayed_job.rb
@@ -6,6 +6,7 @@ module HireFire
       autoload :ActiveRecord,  'hirefire/backend/delayed_job/active_record'
       autoload :ActiveRecord2, 'hirefire/backend/delayed_job/active_record_2'
       autoload :Mongoid,       'hirefire/backend/delayed_job/mongoid'
+      autoload :DataMapper,    'hirefire/backend/delayed_job/data_mapper'
     end
   end
 end

--- a/lib/hirefire/backend/delayed_job/data_mapper.rb
+++ b/lib/hirefire/backend/delayed_job/data_mapper.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+
+module HireFire
+  module Backend
+    module DelayedJob
+      module DataMapper
+
+        ##
+        # Counts the amount of queued jobs in the database,
+        # failed jobs are excluded from the sum
+        #
+        # @return [Fixnum] the amount of pending jobs
+        def jobs
+          ::Delayed::Job.count(:failed_at => nil, :run_at.lte => Time.now.utc)
+        end
+
+        ##
+        # Counts the amount of jobs that are locked by a worker
+        # There is no other performant way to determine the amount
+        # of workers there currently are
+        #
+        # @return [Fixnum] the amount of (assumably working) workers
+        def working
+          ::Delayed::Job.count(:locked_by.not => nil)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/hirefire/environment.rb
+++ b/lib/hirefire/environment.rb
@@ -42,6 +42,20 @@ module HireFire
           after_update  'self.class.environment.fire',
             :unless => Proc.new { |job| job.failed_at.nil? }
         end
+      elsif base.name == "Delayed::Backend::DataMapper::Job"
+        base.send :extend, HireFire::Environment::DelayedJob::ClassMethods
+
+        base.class_eval do
+          after :create do
+            self.class.hirefire_hire
+          end
+          after :destroy do
+            self.class.environment.fire
+          end
+          after :update do
+            self.class.environment.fire unless self.failed_at.nil?
+          end
+        end
       end
 
       Logger.message("#{ base.name } detected!")

--- a/lib/hirefire/initializer.rb
+++ b/lib/hirefire/initializer.rb
@@ -44,6 +44,15 @@ module HireFire
         end
 
         ##
+        # If DelayedJob is using DataMapper, then include
+        # HireFire::Environment in to the DataMapper Delayed Job Backend
+        if defined?(::Delayed::Backend::DataMapper::Job)
+          ::Delayed::Backend::DataMapper::Job.
+          send(:include, HireFire::Environment).
+          send(:include, HireFire::Backend)
+        end
+
+        ##
         # Load Delayed Job extensions, this will patch Delayed::Worker
         # to implement the necessary hooks to invoke HireFire from
         require 'hirefire/workers/delayed_job'

--- a/lib/hirefire/version.rb
+++ b/lib/hirefire/version.rb
@@ -6,7 +6,7 @@ module HireFire
     ##
     # @return [String] the current version of the HireFire gem
     def self.current
-      '0.1.4'
+      '0.1.5'
     end
 
   end

--- a/lib/hirefire/workers/resque/worker.rb
+++ b/lib/hirefire/workers/resque/worker.rb
@@ -20,7 +20,7 @@ module ::Resque
           run_hook :before_fork, job
           working_on job
 
-          if @child = fork
+          if @child = fork(job)
             rand # Reseeding
             procline "Forked #{@child} at #{Time.now.to_i}"
             Process.wait


### PR DESCRIPTION
There appears to be an issue where hirefire gem is not quite up to date with the latest resque 'v1.23.1'.

resque has a change when you call fork you must pass a job to said call. This SHOULD fix that issue.
